### PR TITLE
chore: Add custom comm and reduce op tests; allow diff reduce ops

### DIFF
--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -29,7 +29,7 @@ class CollectiveGroup:
         self,
         input_nodes: List[DAGNode],
         op: ReduceOp,  # [TODO] General collective ops.
-        transport: Union[str, GPUCommunicator] = TorchTensorType.AUTO,
+        transport: Union[str, GPUCommunicator] = TorchTensorType.NCCL,
     ):
         self._input_nodes: List[DAGNode] = input_nodes
         if len(self._input_nodes) == 0:

--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -13,7 +13,7 @@ from ray.dag.constants import (
 )
 from ray.dag.format_utils import get_dag_node_str
 from ray.util.annotations import DeveloperAPI
-from ray.util.collective import types
+from ray.util.collective import nccl_types
 from ray.experimental.channel import ChannelContext
 from ray.experimental.channel.torch_tensor_nccl_channel import _init_nccl_group
 from ray.experimental.channel.torch_tensor_type import (
@@ -32,7 +32,7 @@ class CollectiveGroup:
     def __init__(
         self,
         input_nodes: List[DAGNode],
-        op: types.ReduceOp,  # [TODO] General collective ops.
+        op: nccl_types.ReduceOp,  # [TODO] General collective ops.
         type_hint: Optional[TorchTensorType] = None,
     ):
         self._input_nodes: List[DAGNode] = input_nodes
@@ -98,8 +98,7 @@ class CollectiveGroup:
 
     def method(self, tensor: "torch.Tensor"):
         nccl_group = self.get_nccl_group()
-        assert self._op == types.ReduceOp.SUM, f"Not implemented for {self._op}"
-        nccl_group.allreduce(tensor)
+        nccl_group.allreduce(tensor, self._op)
         return tensor
 
 

--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -13,7 +13,7 @@ from ray.dag.constants import (
 )
 from ray.dag.format_utils import get_dag_node_str
 from ray.util.annotations import DeveloperAPI
-from ray.util.collective import nccl_types
+from ray.util.collective.nccl_types import ReduceOp
 from ray.experimental.channel import ChannelContext
 from ray.experimental.channel.torch_tensor_nccl_channel import _init_nccl_group
 from ray.experimental.channel.torch_tensor_type import (
@@ -32,7 +32,7 @@ class CollectiveGroup:
     def __init__(
         self,
         input_nodes: List[DAGNode],
-        op: nccl_types.ReduceOp,  # [TODO] General collective ops.
+        op: ReduceOp,  # [TODO] General collective ops.
         type_hint: Optional[TorchTensorType] = None,
     ):
         self._input_nodes: List[DAGNode] = input_nodes

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -377,7 +377,7 @@ def test_torch_tensor_custom_comm(ray_start_regular):
         def allreduce(
             self,
             tensor: "torch.Tensor",
-            op: "ReduceOp",
+            op: ReduceOp,
         ):
             raise NotImplementedError
 
@@ -470,7 +470,7 @@ def test_torch_tensor_custom_comm_invalid(ray_start_regular):
         def allreduce(
             self,
             tensor: "torch.Tensor",
-            op: "ReduceOp",
+            op: ReduceOp,
         ):
             raise NotImplementedError
 
@@ -610,7 +610,7 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
         def allreduce(
             self,
             tensor: "torch.Tensor",
-            op: "ReduceOp",
+            op: ReduceOp,
         ):
             raise NotImplementedError
 
@@ -1130,7 +1130,7 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
         def allreduce(
             self,
             tensor: "torch.Tensor",
-            op: "ReduceOp" = ReduceOp.SUM,
+            op: ReduceOp = ReduceOp.SUM,
         ) -> None:
             return self._inner.allreduce(tensor, op)
 

--- a/python/ray/experimental/channel/gpu_communicator.py
+++ b/python/ray/experimental/channel/gpu_communicator.py
@@ -108,7 +108,7 @@ class GPUCommunicator(ABC):
     def allreduce(
         self,
         buf: "torch.Tensor",
-        op: "ray.experimental.collective.types.ReduceOp",
+        op: "ray.util.collective.nccl_types.ReduceOp",
     ):
         """
         Collectively allreduce the tensor across the group.

--- a/python/ray/experimental/channel/gpu_communicator.py
+++ b/python/ray/experimental/channel/gpu_communicator.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 import ray
 from ray.util.annotations import DeveloperAPI
+from ray.util.collective.nccl_types import ReduceOp
 
 if TYPE_CHECKING:
     import torch
@@ -108,7 +109,7 @@ class GPUCommunicator(ABC):
     def allreduce(
         self,
         buf: "torch.Tensor",
-        op: "ray.util.collective.nccl_types.ReduceOp",
+        op: ReduceOp,
     ):
         """
         Collectively allreduce the tensor across the group.

--- a/python/ray/experimental/channel/gpu_communicator.py
+++ b/python/ray/experimental/channel/gpu_communicator.py
@@ -105,6 +105,24 @@ class GPUCommunicator(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def allreduce(
+        self,
+        buf: "torch.Tensor",
+        op: "ray.experimental.collective.types.ReduceOp",
+    ):
+        """
+        Collectively allreduce the tensor across the group.
+
+        Args:
+            tensor: the tensor to be all-reduced on this process.
+            op: The reduce operation.
+
+        Returns:
+            None
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def destroy() -> None:
         """
         Destroy the GPU communicator.

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -209,7 +209,7 @@ class _NcclGroup(GPUCommunicator):
     def allreduce(
         self,
         buf: "torch.Tensor",
-        op: "ReduceOp" = ReduceOp.SUM,
+        op: ReduceOp = ReduceOp.SUM,
     ):
         if self._closed:
             raise RayChannelError("NCCL group has been destroyed.")

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -8,7 +8,7 @@ from ray.experimental.channel.gpu_communicator import (
     GPUCommunicator,
     TorchTensorAllocator,
 )
-from ray.util.collective import nccl_types
+from ray.util.collective.nccl_types import ReduceOp
 
 if TYPE_CHECKING:
     import cupy as cp
@@ -209,7 +209,7 @@ class _NcclGroup(GPUCommunicator):
     def allreduce(
         self,
         buf: "torch.Tensor",
-        op: "nccl_types.ReduceOp" = nccl_types.ReduceOp.SUM,
+        op: "ReduceOp" = ReduceOp.SUM,
     ):
         if self._closed:
             raise RayChannelError("NCCL group has been destroyed.")

--- a/python/ray/experimental/collective/allreduce.py
+++ b/python/ray/experimental/collective/allreduce.py
@@ -23,7 +23,7 @@ class AllReduceWrapper:
         self,
         input_nodes: List["DAGNode"],
         op: ReduceOp = ReduceOp.SUM,
-        transport: Union[str, GPUCommunicator] = TorchTensorType.AUTO,
+        transport: Union[str, GPUCommunicator] = TorchTensorType.NCCL,
     ) -> List[CollectiveOutputNode]:
         # [TODO] Polish.
         """

--- a/python/ray/experimental/collective/allreduce.py
+++ b/python/ray/experimental/collective/allreduce.py
@@ -10,7 +10,8 @@ from ray.dag.constants import (
 )
 from ray.dag.dag_node import DAGNode
 from ray.experimental.channel.torch_tensor_type import TorchTensorType
-from ray.util.collective import types
+from ray.util.collective import nccl_types
+from ray.util.collective import types as ray_types
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ class AllReduceWrapper:
     def bind(
         self,
         input_nodes: List["DAGNode"],
-        op: types.ReduceOp,
+        op: nccl_types.ReduceOp = nccl_types.ReduceOp.SUM,
         type_hint: Optional[TorchTensorType] = None,
     ) -> List[CollectiveOutputNode]:
         # [TODO] Polish.
@@ -70,7 +71,7 @@ class AllReduceWrapper:
         self,
         tensor,
         group_name: str = "default",
-        op: types.ReduceOp = types.ReduceOp.SUM,
+        op: ray_types.ReduceOp = ray_types.ReduceOp.SUM,
     ):
         from ray.util.collective.collective import allreduce
 

--- a/python/ray/experimental/collective/allreduce.py
+++ b/python/ray/experimental/collective/allreduce.py
@@ -10,8 +10,8 @@ from ray.dag.constants import (
 )
 from ray.dag.dag_node import DAGNode
 from ray.experimental.channel.torch_tensor_type import TorchTensorType
-from ray.util.collective import nccl_types
 from ray.util.collective import types as ray_types
+from ray.util.collective.nccl_types import ReduceOp
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class AllReduceWrapper:
     def bind(
         self,
         input_nodes: List["DAGNode"],
-        op: nccl_types.ReduceOp = nccl_types.ReduceOp.SUM,
+        op: ReduceOp = ReduceOp.SUM,
         type_hint: Optional[TorchTensorType] = None,
     ) -> List[CollectiveOutputNode]:
         # [TODO] Polish.

--- a/python/ray/util/collective/nccl_types.py
+++ b/python/ray/util/collective/nccl_types.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ReduceOp(Enum):
+    SUM = 0
+    PRODUCT = 1
+    MAX = 2
+    MIN = 3
+    AVG = 4


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## What is done?

Added tests for: all-reduce with custom communicator (a wrapper of `_NcclGroup`) and all-reduce with different `ReduceOp`s.
Enabled all NCCL `ReduceOp`s.

Added tests for communicator membership checking and deduplication of communicators.

## What is missing?

Tests for custom communicators: a real custom communicator using `torch.distributed` and a broken custom communicator whose membership does not match the actors of all-reduce's input nodes.
Other tests: for op scheduling.

<!-- Please give a short summary of the change and the problem this solves. -->

## What is experimental?

I put the `nccl_types` (which contains the NCCL `ReduceOp`s in `ray.util`) to avoid circular imports.

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
