### PR TITLE
chore: Add test for NCCL group deduplication with custom communicators

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -977,6 +977,7 @@ class CompiledDAG:
         if None in nccl_actors:
             raise ValueError("Driver cannot participate in the NCCL group.")
 
+        # [TODO] Comments.
         if nccl_actors and self._custom_nccl_group is not None:
             self._nccl_group_id = _init_nccl_group(nccl_actors, self._custom_nccl_group)
             actors = frozenset(nccl_actors)

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -968,19 +968,19 @@ class CompiledDAG:
                     # Add all readers to the NCCL group.
                     nccl_actors.add(downstream_actor_handle)
 
+        # [TODO] Comments.
+        actors_to_nccl_group_id: Dict[FrozenSet["ray.actor.ActorHandle"], str] = {}
+
         # If there were type hints indicating transport via NCCL, initialize
         # the NCCL group on the participating actors.
         nccl_actors = list(nccl_actors)
         if None in nccl_actors:
             raise ValueError("Driver cannot participate in the NCCL group.")
 
-        # [TODO] Comments.
-        actors_to_nccl_group_id: Dict[FrozenSet["ray.actor.ActorHandle"], str] = {}
-        if self._nccl_group_id is not None:
-            actors_to_nccl_group_id[frozenset(nccl_actors)] = self._nccl_group_id
-        elif self._custom_nccl_group is not None:
+        if nccl_actors and self._custom_nccl_group is not None:
             self._nccl_group_id = _init_nccl_group(nccl_actors, self._custom_nccl_group)
-            actors_to_nccl_group_id[frozenset(nccl_actors)] = self._nccl_group_id
+            actors = frozenset(nccl_actors)
+            actors_to_nccl_group_id[actors] = self._nccl_group_id
 
         # [TODO] Comments.
         for collective_group in nccl_collective_groups:
@@ -991,6 +991,7 @@ class CompiledDAG:
                 if actors not in actors_to_nccl_group_id:
                     actors_to_nccl_group_id[actors] = nccl_group_id
 
+        # [TODO] Comments.
         if nccl_actors and self._nccl_group_id is None:
             actors = frozenset(nccl_actors)
             if actors in actors_to_nccl_group_id:

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -977,10 +977,8 @@ class CompiledDAG:
         # [TODO] Comments.
         actors_to_nccl_group_id: Dict[FrozenSet["ray.actor.ActorHandle"], str] = {}
         if self._nccl_group_id is not None:
-            print("nccl group already set")
             actors_to_nccl_group_id[frozenset(nccl_actors)] = self._nccl_group_id
         elif self._custom_nccl_group is not None:
-            print("init with custom group", self._custom_nccl_group)
             self._nccl_group_id = _init_nccl_group(nccl_actors, self._custom_nccl_group)
             actors_to_nccl_group_id[frozenset(nccl_actors)] = self._nccl_group_id
 

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1502,7 +1502,7 @@ class CompiledDAG:
                     _DAGNodeOperation(exec_task_idx, _DAGNodeOperationType.COMPUTE),
                     task_index,
                     actor_handle,
-                    requires_nccl or isinstance(dag_node, CollectiveOutputNode),
+                    isinstance(dag_node, CollectiveOutputNode),
                 )
                 write_node = _DAGOperationGraphNode(
                     _DAGNodeOperation(exec_task_idx, _DAGNodeOperationType.WRITE),

--- a/python/ray/dag/dag_node_operation.py
+++ b/python/ray/dag/dag_node_operation.py
@@ -150,7 +150,7 @@ class _DAGOperationGraphNode:
             elif is_nccl_compute and other_is_nccl_compute:
                 return tie_breaker(self, other)
             else:
-                return not is_nccl_write
+                return is_nccl_write
 
     def __eq__(self, other: "_DAGOperationGraphNode"):
         """

--- a/python/ray/dag/dag_node_operation.py
+++ b/python/ray/dag/dag_node_operation.py
@@ -148,8 +148,12 @@ class _DAGOperationGraphNode:
             if is_nccl_write and other_is_nccl_write:
                 return tie_breaker(self, other)
             elif is_nccl_compute and other_is_nccl_compute:
-                return tie_breaker(self, other)
+                if self.task_idx != other.task_idx:
+                    return self.task_idx < other.task_idx
+                return self.operation.exec_task_idx < other.operation.exec_task_idx
             else:
+                # [TODO] Comment. Prioritize NCCL writes and reads before
+                # NCCL collectives.
                 return is_nccl_write
 
     def __eq__(self, other: "_DAGOperationGraphNode"):

--- a/python/ray/dag/dag_node_operation.py
+++ b/python/ray/dag/dag_node_operation.py
@@ -148,9 +148,8 @@ class _DAGOperationGraphNode:
             if is_nccl_write and other_is_nccl_write:
                 return tie_breaker(self, other)
             elif is_nccl_compute and other_is_nccl_compute:
-                if self.task_idx != other.task_idx:
-                    return self.task_idx < other.task_idx
-                return self.operation.exec_task_idx < other.operation.exec_task_idx
+                # [TODO] Select only collective groups that are ready.
+                return tie_breaker(self, other)
             else:
                 # [TODO] Comment. Prioritize NCCL writes and reads before
                 # NCCL collectives.

--- a/python/ray/dag/tests/experimental/test_execution_schedule.py
+++ b/python/ray/dag/tests/experimental/test_execution_schedule.py
@@ -35,14 +35,17 @@ def mock_init(self):
     pass
 
 
-def generate_dag_graph_nodes(local_idx, dag_idx, actor_handle, requires_nccl):
+def generate_dag_graph_nodes(
+    local_idx, dag_idx, actor_handle, requires_nccl, is_collective=False
+):
     graph_nodes = {}
     for op_type in _DAGNodeOperationType:
         graph_nodes[op_type] = _DAGOperationGraphNode(
             _DAGNodeOperation(local_idx, op_type),
             dag_idx,
             actor_handle,
-            (requires_nccl if op_type == _DAGNodeOperationType.WRITE else False),
+            (op_type == _DAGNodeOperationType.WRITE and requires_nccl)
+            or (op_type == _DAGNodeOperationType.COMPUTE and is_collective),
         )
     return graph_nodes
 
@@ -225,6 +228,154 @@ class TestSelectNextNodes:
             assert len(next_nodes) == 2
             assert next_nodes[0] == mock_graph[dag_idx_1_0][_DAGNodeOperationType.WRITE]
             assert next_nodes[1] == mock_graph[dag_idx_2_1][_DAGNodeOperationType.READ]
+
+    def test_two_ready_nccl_collectives(self, monkeypatch):
+        """
+        Simulate the case where the only candidates are NCCL collective
+        operations. In this case, `_select_next_nodes` should return all
+        NCCL collective operations of the earliest-bound collective group together.
+
+        driver -> fake_actor_1.allreduce_1 -> driver
+               |                            |
+               -> fake_actor_2.allreduce_1 ->
+               |                            |
+               -> fake_actor_2.allreduce_2 ->
+
+        In the example above, there are 2 allreduce groups, with one group
+        including both actors and the other group including fake_actor_2.
+        The following test case simulates a scenario where the READ
+        operation for every all-reduce input has already been added to the
+        execution schedule.
+        """
+        monkeypatch.setattr(ActorHandle, "__init__", mock_actor_handle_init)
+        fake_actor_1, dag_idx_1, local_idx_1 = ActorHandle("fake_actor_1"), 1, 0
+        fake_actor_2, dag_idx_2, local_idx_2 = ActorHandle("fake_actor_2"), 2, 0
+        dag_idx_3, local_idx_3 = 3, 1
+        mock_graph = {
+            dag_idx_1: generate_dag_graph_nodes(
+                local_idx_1, dag_idx_1, fake_actor_1, False, is_collective=True
+            ),
+            dag_idx_2: generate_dag_graph_nodes(
+                local_idx_2, dag_idx_2, fake_actor_2, False, is_collective=True
+            ),
+            dag_idx_3: generate_dag_graph_nodes(
+                local_idx_3, dag_idx_3, fake_actor_2, False, is_collective=True
+            ),
+        }
+        del mock_graph[dag_idx_1][_DAGNodeOperationType.READ]
+        del mock_graph[dag_idx_2][_DAGNodeOperationType.READ]
+        del mock_graph[dag_idx_3][_DAGNodeOperationType.READ]
+
+        _add_edge(
+            mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE],
+            mock_graph[dag_idx_1][_DAGNodeOperationType.WRITE],
+        )
+        _add_edge(
+            mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE],
+            mock_graph[dag_idx_2][_DAGNodeOperationType.WRITE],
+        )
+        _add_edge(
+            mock_graph[dag_idx_3][_DAGNodeOperationType.COMPUTE],
+            mock_graph[dag_idx_3][_DAGNodeOperationType.WRITE],
+        )
+        mock_actor_to_candidates = {
+            fake_actor_1: [mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_2: [
+                mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE],
+                mock_graph[dag_idx_3][_DAGNodeOperationType.COMPUTE],
+            ],
+        }
+        # Embed collective group information in _DAGNodeOperation.
+        mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE].set_collective_edges(
+            {(dag_idx_2, _DAGNodeOperationType.COMPUTE)}
+        )
+        mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE].set_collective_edges(
+            {(dag_idx_1, _DAGNodeOperationType.COMPUTE)}
+        )
+        next_nodes = _select_next_nodes(mock_actor_to_candidates, mock_graph)
+        assert len(next_nodes) == 2
+        assert set(next_nodes) == {
+            mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE],
+            mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE],
+        }
+
+    def test_nccl_collectives_one_ready_one_partial(self, monkeypatch):
+        """
+        Simulate the case where the only candidates are NCCL collective
+        operations. In this case, `_select_next_nodes` should return all
+        NCCL collective operations of the earliest-bound collective group
+        that is ready.
+
+        driver -> fake_actor_1.allreduce_1 -> driver
+               |                            |
+               -> fake_actor_1.allreduce_2 ->
+               |                            |
+               -> fake_actor_2.allreduce_2 ->
+
+        with InputNode() as inp:  # (0,)
+            x = fake_actor_1.get_tensor.bind(inp)  # (1, 0)
+            y = fake_actor_2.get_tensor.bind(inp)  # (2, 0)
+            t = fake_actor_1.get_tensor.bind(inp)  # (3, 1)
+
+            allreduce_1 = collective.allreduce.bind([x])
+            z = allreduce_1[0]  # (4, 2)
+
+            allreduce_2 = collective.allreduce.bind([y, z])  # (5, 1) (6, 3)
+
+        In the example above, there are 2 allreduce groups, with the first group
+        including fake_actor_1 and the second group including both actors.
+        The following test case simulates a scenario where the READ
+        operations for x and y have already been added to the
+        execution schedule.
+        """
+        monkeypatch.setattr(ActorHandle, "__init__", mock_actor_handle_init)
+        fake_actor_1, dag_idx_1, local_idx_1 = ActorHandle("fake_actor_1"), 4, 2
+        fake_actor_2, dag_idx_2, local_idx_2 = ActorHandle("fake_actor_2"), 5, 1
+        dag_idx_3, local_idx_3 = 6, 3
+        mock_graph = {
+            dag_idx_1: generate_dag_graph_nodes(
+                local_idx_1, dag_idx_1, fake_actor_1, False, is_collective=True
+            ),
+            dag_idx_2: generate_dag_graph_nodes(
+                local_idx_2, dag_idx_2, fake_actor_2, False, is_collective=True
+            ),
+            dag_idx_3: generate_dag_graph_nodes(
+                local_idx_3, dag_idx_3, fake_actor_1, False, is_collective=True
+            ),
+        }
+        del mock_graph[dag_idx_1][_DAGNodeOperationType.READ]
+        del mock_graph[dag_idx_2][_DAGNodeOperationType.READ]
+
+        _add_edge(
+            mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE],
+            mock_graph[dag_idx_1][_DAGNodeOperationType.WRITE],
+        )
+        _add_edge(
+            mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE],
+            mock_graph[dag_idx_2][_DAGNodeOperationType.WRITE],
+        )
+        _add_edge(
+            mock_graph[dag_idx_3][_DAGNodeOperationType.COMPUTE],
+            mock_graph[dag_idx_3][_DAGNodeOperationType.WRITE],
+        )
+        _add_edge(
+            mock_graph[dag_idx_1][_DAGNodeOperationType.WRITE],
+            mock_graph[dag_idx_3][_DAGNodeOperationType.READ],
+        )
+        mock_actor_to_candidates = {
+            fake_actor_1: [mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_2: [mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE]],
+        }
+        # Embed collective group information in _DAGNodeOperation.
+        mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE].set_collective_edges(
+            {(dag_idx_3, _DAGNodeOperationType.COMPUTE)}
+        )
+        mock_graph[dag_idx_3][_DAGNodeOperationType.COMPUTE].set_collective_edges(
+            {(dag_idx_2, _DAGNodeOperationType.COMPUTE)}
+        )
+        next_nodes = _select_next_nodes(mock_actor_to_candidates, mock_graph)
+        assert len(next_nodes) == 1
+        assert next_nodes[0] == mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]
 
 
 class TestBuildDAGNodeOperationGraph:

--- a/python/ray/dag/tests/experimental/test_execution_schedule.py
+++ b/python/ray/dag/tests/experimental/test_execution_schedule.py
@@ -42,7 +42,7 @@ def generate_dag_graph_nodes(local_idx, dag_idx, actor_handle, requires_nccl):
             _DAGNodeOperation(local_idx, op_type),
             dag_idx,
             actor_handle,
-            requires_nccl,
+            (requires_nccl if op_type == _DAGNodeOperationType.WRITE else False),
         )
     return graph_nodes
 

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -1795,6 +1795,46 @@ def test_torch_tensor_nccl_all_reduce_scheduling(ray_start_regular):
     assert result == (value, shape, dtype)
 
 
+@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+def test_torch_tensor_nccl_all_reduce_scheduling_one_ready(ray_start_regular):
+    """
+    Test that scheduling avoids deadlocks when allreduce is used.
+    """
+    if not USE_GPU:
+        pytest.skip("NCCL tests require GPUs")
+
+    assert (
+        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
+    ), "This test requires at least 2 GPUs"
+
+    actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
+
+    num_workers = 2
+    workers = [actor_cls.remote() for _ in range(num_workers)]
+
+    shape = (10,)
+    dtype = torch.float16
+    with InputNode() as inp:  # (0,)
+        x = workers[0].send.bind(shape, dtype, inp)  # (1, 0)
+        y = workers[1].send.bind(shape, dtype, inp)  # (2, 0)
+        t = workers[0].send.bind(shape, dtype, inp)  # (3, 1)
+
+        allreduce_1 = collective.allreduce.bind([x])
+        z = allreduce_1[0]  # (4, 2)
+
+        allreduce_2 = collective.allreduce.bind([y, z])  # (5, 1) (6, 3)
+        recv_0 = workers[0].recv.bind(allreduce_2[0])
+        recv_1 = workers[1].recv.bind(allreduce_2[1])
+        dag = MultiOutputNode([recv_0, recv_1])
+
+    compiled_dag = dag.experimental_compile()
+
+    value = 10
+    ref = compiled_dag.execute(value)
+    result = ray.get(ref)
+    assert result == [(value * 2, shape, dtype) for _ in workers]
+
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -1680,7 +1680,7 @@ def test_torch_tensor_nccl_deduplicate_custom_comm(ray_start_regular):
     assert set(nccl_group.get_actor_handles()) == set(workers)
     assert nccl_group == comm
 
-    # Should P2P NCCL group be the same?
+    # P2P and NCCL group should be the same.
     assert compiled_dag._nccl_group_id == nccl_group_id
 
     # Sanity check: the compiled dag can execute.
@@ -1741,7 +1741,7 @@ def test_torch_tensor_nccl_deduplicate_custom_comm(ray_start_regular):
         comm._inner,
     )
 
-    # Should P2P NCCL group be the same?
+    # P2P and NCCL group should be the same.
     assert compiled_dag._nccl_group_id == nccl_group_id
 
     # Sanity check: the compiled dag can execute.
@@ -1779,7 +1779,7 @@ def test_torch_tensor_nccl_all_reduce_scheduling(ray_start_regular):
         x = workers[0].send.bind(shape, dtype, inp)
         y = workers[1].send.bind(shape, dtype, inp)
 
-        # Tensor to be sent from workes[0] to workers[1]
+        # Tensor to be sent from workes[0] to workers[1].
         t = workers[0].send.bind(shape, dtype, inp)
         t.with_type_hint(TorchTensorType(transport="nccl"))
 
@@ -1796,47 +1796,47 @@ def test_torch_tensor_nccl_all_reduce_scheduling(ray_start_regular):
     expected_tensor_value = torch.ones(shape, dtype=dtype) * reduced_value
     assert torch.equal(result[0], expected_tensor_value)
     assert torch.equal(result[1], expected_tensor_value)
-    assert result[-1] == (value, shape, dtype)
+    assert result[2] == (value, shape, dtype)
 
 
-@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
-def test_torch_tensor_nccl_all_reduce_scheduling_one_ready(ray_start_regular):
-    """
-    Test that scheduling avoids deadlocks when allreduce is used.
-    """
-    if not USE_GPU:
-        pytest.skip("NCCL tests require GPUs")
+# @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+# def test_torch_tensor_nccl_all_reduce_scheduling_one_ready(ray_start_regular):
+#     """
+#     Test that scheduling avoids deadlocks when allreduce is used.
+#     """
+#     if not USE_GPU:
+#         pytest.skip("NCCL tests require GPUs")
 
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+#     assert (
+#         sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
+#     ), "This test requires at least 2 GPUs"
 
-    actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
+#     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
-    num_workers = 2
-    workers = [actor_cls.remote() for _ in range(num_workers)]
+#     num_workers = 2
+#     workers = [actor_cls.remote() for _ in range(num_workers)]
 
-    shape = (10,)
-    dtype = torch.float16
-    with InputNode() as inp:  # (0,)
-        x = workers[0].send.bind(shape, dtype, inp)  # (1, 0)
-        y = workers[1].send.bind(shape, dtype, inp)  # (2, 0)
-        t = workers[0].send.bind(shape, dtype, inp)  # (3, 1)
+#     shape = (10,)
+#     dtype = torch.float16
+#     with InputNode() as inp:  # (task_idx, exec_task_idx): (0,)
+#         x = workers[0].send.bind(shape, dtype, inp)  # (1, 0)
+#         y = workers[1].send.bind(shape, dtype, inp)  # (2, 0)
+#         t = workers[0].send.bind(shape, dtype, inp)  # (3, 1)
 
-        allreduce_1 = collective.allreduce.bind([x])
-        z = allreduce_1[0]  # (4, 2)
+#         allreduce_1 = collective.allreduce.bind([x])
+#         z = allreduce_1[0]  # (4, 2)
 
-        allreduce_2 = collective.allreduce.bind([y, z])  # (5, 1) (6, 3)
-        recv_0 = workers[0].recv.bind(allreduce_2[0])
-        recv_1 = workers[1].recv.bind(allreduce_2[1])
-        dag = MultiOutputNode([recv_0, recv_1])
+#         allreduce_2 = collective.allreduce.bind([y, z])  # (5, 1) (6, 3)
+#         recv_0 = workers[0].recv.bind(allreduce_2[0])
+#         recv_1 = workers[1].recv.bind(allreduce_2[1])
+#         dag = MultiOutputNode([recv_0, recv_1])
 
-    compiled_dag = dag.experimental_compile()
+#     compiled_dag = dag.experimental_compile()
 
-    value = 10
-    ref = compiled_dag.execute(value)
-    result = ray.get(ref)
-    assert result == [(value * 2, shape, dtype) for _ in workers]
+#     value = 10
+#     ref = compiled_dag.execute(value)
+#     result = ray.get(ref)
+#     assert result == [(value * 2, shape, dtype) for _ in workers]
 
 
 if __name__ == "__main__":

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -1694,7 +1694,6 @@ def test_torch_tensor_nccl_deduplicate_custom_comm(ray_start_regular):
 
     comm_id = nccl.get_unique_id()
     comm = TestNcclGroup(num_workers, comm_id, workers)
-    print("original custom group", comm)
     with InputNode() as inp:
         computes = [
             worker.compute_with_tuple_args.bind(inp, i)
@@ -1726,7 +1725,6 @@ def test_torch_tensor_nccl_deduplicate_custom_comm(ray_start_regular):
     ctx = ChannelContext.get_current()
     nccl_group_id = list(nccl_group_ids)[0]
     nccl_group = ctx.nccl_groups[nccl_group_id]
-    print(ctx.nccl_groups)
     assert set(nccl_group.get_actor_handles()) == set(workers)
     # The following assertion fails because TorchTensorType is deep-copied as a whole.
     # assert nccl_group == comm

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -1344,7 +1344,7 @@ def test_torch_tensor_nccl_comm_deduplicate_collectives(ray_start_regular):
             dag_node = compiled_dag.idx_to_task[exec_task.task_idx].dag_node
             if isinstance(dag_node, CollectiveOutputNode):
                 assert exec_task.collective_group is not None
-                nccl_group_id = exec_task.collective_group._type_hint._nccl_group_id
+                nccl_group_id = exec_task.collective_group.type_hint.nccl_group_id
                 assert nccl_group_id is not None
                 nccl_group_ids.add(nccl_group_id)
     # Only 1 NCCL group should be created.
@@ -1459,7 +1459,7 @@ def test_torch_tensor_nccl_comm_deduplicate_collective_and_p2p(ray_start_regular
             dag_node = compiled_dag.idx_to_task[exec_task.task_idx].dag_node
             if isinstance(dag_node, CollectiveOutputNode):
                 assert exec_task.collective_group is not None
-                nccl_group_id = exec_task.collective_group._type_hint._nccl_group_id
+                nccl_group_id = exec_task.collective_group.type_hint.nccl_group_id
                 assert nccl_group_id is not None
                 nccl_group_ids.add(nccl_group_id)
 
@@ -1531,7 +1531,7 @@ def test_torch_tensor_nccl_all_reduce_diff_comms(ray_start_regular):
             dag_node = compiled_dag.idx_to_task[exec_task.task_idx].dag_node
             if isinstance(dag_node, CollectiveOutputNode):
                 assert exec_task.collective_group is not None
-                nccl_group_id = exec_task.collective_group._type_hint._nccl_group_id
+                nccl_group_id = exec_task.collective_group.type_hint.nccl_group_id
                 assert nccl_group_id is not None
                 nccl_group_ids.add(nccl_group_id)
 
@@ -1555,6 +1555,203 @@ def test_torch_tensor_nccl_all_reduce_diff_comms(ray_start_regular):
     ref = compiled_dag.execute([(shape, dtype, i + 1) for i in range(num_workers)])
     result = ray.get(ref)
     assert result == [(i + 1, shape, dtype) for i in range(num_workers)]
+
+    compiled_dag.teardown()
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+def test_torch_tensor_nccl_deduplicate_custom_comm(ray_start_regular):
+    """
+    Test that a custom GPU communicator is reused when appropriate.
+    """
+    if not USE_GPU:
+        pytest.skip("NCCL tests require GPUs")
+
+    assert (
+        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
+    ), "This test requires at least 2 GPUs"
+
+    actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
+
+    num_workers = 2
+    workers = [actor_cls.remote() for _ in range(num_workers)]
+
+    class TestNcclGroup(GPUCommunicator):
+        """
+        A custom NCCL group for testing. This is a simple wrapper around `_NcclGroup`.
+        """
+
+        def __init__(self, world_size, comm_id, actor_handles):
+            self._world_size = world_size
+            self._comm_id = comm_id
+            self._actor_handles = actor_handles
+            self._inner = None
+
+        def initialize(self, rank: int) -> None:
+            self._inner = _NcclGroup(
+                self._world_size,
+                self._comm_id,
+                rank,
+                self._actor_handles,
+                torch.cuda.current_stream().cuda_stream,
+            )
+
+        def get_rank(self, actor: ray.actor.ActorHandle) -> int:
+            # Implement this without forwarding to `_inner` to allow the method
+            # to be called before initialization.
+            actor_ids = [a._ray_actor_id for a in self._actor_handles]
+            try:
+                rank = actor_ids.index(actor._ray_actor_id)
+            except ValueError:
+                raise ValueError("Actor is not in the NCCL group.")
+            return rank
+
+        def get_world_size(self) -> int:
+            # Implement this without forwarding to `_inner` to allow the method
+            # to be called before initialization.
+            return self._world_size
+
+        def get_self_rank(self) -> Optional[int]:
+            if self._inner is None:
+                return None
+            return self._inner.get_self_rank()
+
+        def get_actor_handles(self) -> List["ray.actor.ActorHandle"]:
+            return self._actor_handles
+
+        def send(self, value: "torch.Tensor", peer_rank: int) -> None:
+            return self._inner.send(value, peer_rank)
+
+        def recv(
+            self,
+            shape: Tuple[int],
+            dtype: "torch.dtype",
+            peer_rank: int,
+            allocator: Optional[TorchTensorAllocator] = None,
+        ) -> "torch.Tensor":
+            return self._inner.recv(shape, dtype, peer_rank, allocator=allocator)
+
+        def allreduce(
+            self,
+            tensor: "torch.Tensor",
+            op: ReduceOp = ReduceOp.SUM,
+        ) -> None:
+            return self._inner.allreduce(tensor, op)
+
+        def destroy(self) -> None:
+            return self._inner.destroy()
+
+    from cupy.cuda import nccl
+
+    comm_id = nccl.get_unique_id()
+    comm = TestNcclGroup(num_workers, comm_id, workers)
+    with InputNode() as inp:
+        computes = [
+            worker.compute_with_tuple_args.bind(inp, i)
+            for i, worker in enumerate(workers)
+        ]
+        collectives = collective.allreduce.bind(computes, transport=comm)
+        collectives = collective.allreduce.bind(collectives)
+        dag = workers[0].recv.bind(
+            collectives[1].with_type_hint(TorchTensorType(transport="nccl"))
+        )
+
+    compiled_dag = dag.experimental_compile()
+
+    from ray.dag.collective_node import CollectiveOutputNode
+    from ray.experimental.channel import ChannelContext
+
+    nccl_group_ids = set()
+    for _, exec_tasks in compiled_dag.actor_to_executable_tasks.items():
+        for exec_task in exec_tasks:
+            dag_node = compiled_dag.idx_to_task[exec_task.task_idx].dag_node
+            if isinstance(dag_node, CollectiveOutputNode):
+                assert exec_task.collective_group is not None
+                nccl_group_id = exec_task.collective_group.type_hint.nccl_group_id
+                assert nccl_group_id is not None
+                nccl_group_ids.add(nccl_group_id)
+
+    # Exactly 1 NCCL group should be created.
+    assert len(nccl_group_ids) == 1
+    ctx = ChannelContext.get_current()
+    nccl_group_id = list(nccl_group_ids)[0]
+    nccl_group = ctx.nccl_groups[nccl_group_id]
+    assert set(nccl_group.get_actor_handles()) == set(workers)
+    assert nccl_group == comm
+
+    # Should P2P NCCL group be the same?
+    assert compiled_dag._nccl_group_id == nccl_group_id
+
+    # Sanity check: the compiled dag can execute.
+    shape = (10,)
+    dtype = torch.float16
+    value = 10
+    ref = compiled_dag.execute([(shape, dtype, value) for _ in workers])
+    result = ray.get(ref)
+    assert result == (value * num_workers * 2, shape, dtype)
+
+    compiled_dag.teardown()
+
+    comm_id = nccl.get_unique_id()
+    comm = TestNcclGroup(num_workers, comm_id, workers)
+    print("original custom group", comm)
+    with InputNode() as inp:
+        computes = [
+            worker.compute_with_tuple_args.bind(inp, i)
+            for i, worker in enumerate(workers)
+        ]
+        collectives = collective.allreduce.bind(computes)
+        collectives = collective.allreduce.bind(collectives)
+        dag = workers[0].recv.bind(
+            collectives[1].with_type_hint(TorchTensorType(transport=comm))
+        )
+
+    compiled_dag = dag.experimental_compile()
+
+    from ray.dag.collective_node import CollectiveOutputNode
+    from ray.experimental.channel import ChannelContext
+
+    nccl_group_ids = set()
+    for _, exec_tasks in compiled_dag.actor_to_executable_tasks.items():
+        for exec_task in exec_tasks:
+            dag_node = compiled_dag.idx_to_task[exec_task.task_idx].dag_node
+            if isinstance(dag_node, CollectiveOutputNode):
+                assert exec_task.collective_group is not None
+                nccl_group_id = exec_task.collective_group.type_hint.nccl_group_id
+                assert nccl_group_id is not None
+                nccl_group_ids.add(nccl_group_id)
+
+    # Exactly 1 NCCL group should be created.
+    assert len(nccl_group_ids) == 1
+    ctx = ChannelContext.get_current()
+    nccl_group_id = list(nccl_group_ids)[0]
+    nccl_group = ctx.nccl_groups[nccl_group_id]
+    print(ctx.nccl_groups)
+    assert set(nccl_group.get_actor_handles()) == set(workers)
+    # The following assertion fails because TorchTensorType is deep-copied as a whole.
+    # assert nccl_group == comm
+    assert (
+        nccl_group._world_size,
+        nccl_group._comm_id,
+        nccl_group._actor_handles,
+        nccl_group._inner,
+    ) == (
+        comm._world_size,
+        comm._comm_id,
+        comm._actor_handles,
+        comm._inner,
+    )
+
+    # Should P2P NCCL group be the same?
+    assert compiled_dag._nccl_group_id == nccl_group_id
+
+    # Sanity check: the compiled dag can execute.
+    shape = (10,)
+    dtype = torch.float16
+    value = 10
+    ref = compiled_dag.execute([(shape, dtype, value) for _ in workers])
+    result = ray.get(ref)
+    assert result == (value * num_workers * 2, shape, dtype)
 
     compiled_dag.teardown()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## What is done?

A test for NCCL group deduplication that involves custom communicators is added.
A test for scheduling.

<!-- Please give a short summary of the change and the problem this solves. -->

## What is missing?

When there are multiple all-reduce groups, the group we pick should have all its members ready.

<!-- For example: "Closes #1234" -->

## What is experimental?

I changed the code that initializes P2P NCCL group for the dag: Now, if a custom communicator is specified in a collective call, the custom communicator can be reused for P2P. It may worth discussing whether this should be the default behavior, and whether we should add a flag to allow users to explicitly allow or disallow reusing their communicators.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
